### PR TITLE
Remove using i_malloc stale MPI header

### DIFF
--- a/hpat/_distributed.cpp
+++ b/hpat/_distributed.cpp
@@ -80,11 +80,8 @@ PyMODINIT_FUNC PyInit_hdist(void) {
                             PyLong_FromVoidPtr((void*)(&oneD_reshape_shuffle)));
     PyObject_SetAttrString(m, "permutation_int",
                             PyLong_FromVoidPtr((void*)(&permutation_int)));
-    PyObject_SetAttrString(
-        m, "permutation_array_index",
-        PyLong_FromVoidPtr((void*)(&permutation_array_index)));
-    PyObject_SetAttrString(m, "fix_i_malloc",
-                            PyLong_FromVoidPtr((void*)(&fix_i_malloc)));
+    PyObject_SetAttrString(m, "permutation_array_index",
+                            PyLong_FromVoidPtr((void*)(&permutation_array_index)));
 
     // add actual int value to module
     PyObject_SetAttrString(m, "mpi_req_num_bytes",

--- a/hpat/_distributed.h
+++ b/hpat/_distributed.h
@@ -81,7 +81,6 @@ static void permutation_int(int64_t* output, int n) __UNUSED__;
 static void permutation_array_index(unsigned char *lhs, int64_t len, int64_t elem_size,
                                     unsigned char *rhs, int64_t *p, int64_t p_len) __UNUSED__;
 static int hpat_finalize() __UNUSED__;
-static void fix_i_malloc() __UNUSED__;
 static int hpat_dummy_ptr[64] __UNUSED__;
 
 /* *********************************************************************
@@ -825,20 +824,5 @@ static void oneD_reshape_shuffle(char* output,
     delete[] send_disp;
     delete[] recv_disp;
 }
-
-// fix for tensorflows MKL support that overwrites Intel mallocs,
-// which causes Intel MPI to crash.
-#ifdef I_MPI_VERSION
-#include "i_malloc.h"
-static void fix_i_malloc()
-{
-    i_malloc = malloc;
-    i_calloc = calloc;
-    i_realloc = realloc;
-    i_free = free;
-}
-#else
-static void fix_i_malloc() {}
-#endif
 
 #endif // _DISTRIBUTED_H_INCLUDED

--- a/hpat/distributed_lower.py
+++ b/hpat/distributed_lower.py
@@ -549,13 +549,6 @@ def dist_permutation_array_index(lhs, lhs_len, dtype_size, rhs, p, p_len):
     permutation_array_index(lhs.ctypes, lhs_len, elem_size, c_rhs.ctypes,
                             p.ctypes, p_len)
 
-
-ll.add_symbol('fix_i_malloc', hdist.fix_i_malloc)
-_fix_i_malloc = types.ExternalFunction("fix_i_malloc",  types.void())
-@numba.njit
-def fix_i_malloc():
-    _fix_i_malloc()
-
 ########### finalize MPI when exiting ####################
 
 def hpat_finalize():


### PR DESCRIPTION
The "i_malloc.h" header file does not exist since PSXE 2019.
The "fix_i_malloc()" function is used as workaround for "fix
for tensorflows MKL support that overwrites Intel mallocs
which causes Intel MPI to crash"

Remove "i_malloc.h" include and all references to fix_i_malloc() function.