### PR TITLE
Move to use Intel IMPI conda package for Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,16 +31,17 @@ environment easily (Linux/Mac/Windows)::
 .. used if master of Numba is needed for latest hpat package
 .. conda create -n HPAT -c ehsantn -c numba/label/dev -c anaconda -c conda-forge hpat
 
-Windows installaton requires
-`Intel MPI <https://software.intel.com/en-us/intel-mpi-library>`_ to be
-installed.
-
 Docker Container
 ----------------
 
 An HPAT docker image is also available for running containers. For example::
 
     docker run -it ehsantn/hpat bash
+
+Building HPAT from Source
+-------------------------
+
+To build HPAT from Source, please refer to the following `instrunction <docs/source/install.rst>`_
 
 Example
 #######

--- a/buildscripts/hpat-conda-recipe/meta.yaml
+++ b/buildscripts/hpat-conda-recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - hdf5
     - h5py
     - mpich # [not win]
+    - impi-devel # [win]
+    - impi_rt # [win]
 
   run:
     - python
@@ -35,6 +37,7 @@ requirements:
     - boost
     - numba 0.44.*
     - mpich # [not win]
+    - impi_rt # [win]
 
 test:
   requires:
@@ -46,7 +49,7 @@ test:
 
 
 about:
-  home: https://github.com/IntelLabs/hpat
+  home: https://github.com/IntelPython/hpat
   license: BSD
   license_file: LICENSE.md
   summary: A compiler-based big data framework in Python

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,10 +11,6 @@ easily. On Linux/Mac/Windows::
 .. used if master of Numba is needed for latest hpat package
 .. conda create -n HPAT -c ehsantn -c numba/label/dev -c anaconda -c conda-forge hpat
 
-Windows installaton requires
-`Intel MPI <https://software.intel.com/en-us/intel-mpi-library>`_ to be
-installed.
-
 Building HPAT from Source
 -------------------------
 
@@ -26,17 +22,12 @@ such as Numba on Ubuntu Linux::
     chmod +x miniconda.sh
     ./miniconda.sh -b
     export PATH=$HOME/miniconda3/bin:$PATH
-    conda create -n HPAT -q -y numpy scipy pandas boost cmake
+    conda create -n HPAT python=<3.7 or 3.6>
     source activate HPAT
-    conda install -c numba/label/dev numba
-    conda install mpich mpi -c conda-forge
-    conda install pyarrow
-    conda install h5py -c ehsantn
-    conda install gcc_linux-64 gxx_linux-64 gfortran_linux-64
-    git clone https://github.com/IntelLabs/hpat
-    cd hpat
+    conda install conda-build
+    git clone https://github.com/IntelPython/hpat
     # build HPAT
-    HDF5_DIR=$CONDA_PREFIX python setup.py develop
+    conda build --python <3.6 or 3.7> -c numba -c conda-forge -c defaults hpat/buildscripts/hpat-conda-recipe/
 
 
 A command line for running the Pi example on 4 cores::
@@ -57,24 +48,18 @@ to check the channel of ``hdf5`` package.
 Building from Source on Windows
 -------------------------------
 
-Building HPAT on Windows requires Build Tools for Visual Studio 2017 (14.0) and Intel MPI:
+Building HPAT on Windows requires Build Tools for Visual Studio 2017 (14.0):
 
 * Install `Build Tools for Visual Studio 2017 (14.0) <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
-* Install `Intel MPI <https://software.intel.com/en-us/intel-mpi-library>`_.
 * Install `Miniconda for Windows <https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_.
 * Start 'Anaconda prompt'
 * Setup the Conda environment in Anaconda Prompt::
 
-    conda create -n HPAT -c ehsantn -c numba/label/dev -c anaconda -c conda-forge python=3.7 pandas pyarrow h5py numba scipy boost libboost tbb-devel mkl-devel
+    conda create -n HPAT python=<3.7 or 3.6>
     activate HPAT
     conda install vc vs2015_runtime vs2015_win-64
-    git clone https://github.com/IntelLabs/hpat.git
-    cd hpat
-    set INCLUDE=%INCLUDE%;%CONDA_PREFIX%\Library\include
-    set LIB=%LIB%;%CONDA_PREFIX%\Library\lib
-    "%I_MPI_ROOT%"\intel64\bin\mpivars.bat
-    set HDF5_DIR=%CONDA_PREFIX%\Library
-    python setup.py develop
+    git clone https://github.com/IntelPython/hpat.git
+    conda build --python <3.6 or 3.7> -c numba -c conda-forge -c defaults -c intel hpat/buildscripts/hpat-conda-recipe/
 
 .. "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -15,19 +15,44 @@ Building HPAT from Source
 -------------------------
 
 We use `Anaconda <https://www.anaconda.com/download/>`_ distribution of
-Python for setting up HPAT. These commands install HPAT and its dependencies
-such as Numba on Ubuntu Linux::
+Python for setting up HPAT.
+
+Miniconda3 is required for build::
 
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     chmod +x miniconda.sh
     ./miniconda.sh -b
     export PATH=$HOME/miniconda3/bin:$PATH
+
+It is possible to build HPAT via conda-build or setuptools. Follow one of the cases below to install HPAT and its dependencies
+such as Numba on Ubuntu Linux.
+
+Build with conda-build:
+~~~~~~~~~~~~~~~~~~~~~~~
+::
+
     conda create -n HPAT python=<3.7 or 3.6>
     source activate HPAT
     conda install conda-build
     git clone https://github.com/IntelPython/hpat
     # build HPAT
     conda build --python <3.6 or 3.7> -c numba -c conda-forge -c defaults hpat/buildscripts/hpat-conda-recipe/
+
+Build with setuptools:
+~~~~~~~~~~~~~~~~~~~~~~
+::
+
+    conda create -n HPAT -q -y numpy scipy pandas boost cmake python=<3.6 or 3.7>
+    source activate HPAT
+    conda install -c numba/label/dev numba
+    conda install mpich mpi -c conda-forge
+    conda install pyarrow
+    conda install h5py -c ehsantn
+    conda install gcc_linux-64 gxx_linux-64 gfortran_linux-64
+    git clone https://github.com/IntelPython/hpat
+    cd hpat
+    # build HPAT
+    HDF5_DIR=$CONDA_PREFIX python setup.py develop
 
 
 A command line for running the Pi example on 4 cores::
@@ -55,11 +80,32 @@ Building HPAT on Windows requires Build Tools for Visual Studio 2017 (14.0):
 * Start 'Anaconda prompt'
 * Setup the Conda environment in Anaconda Prompt::
 
+It is possible to build HPAT via conda-build or setuptools. Follow one of the cases below to install HPAT and its dependencies on Windows.
+
+Build with conda-build:
+~~~~~~~~~~~~~~~~~~~~~~~
+::
+
     conda create -n HPAT python=<3.7 or 3.6>
     activate HPAT
     conda install vc vs2015_runtime vs2015_win-64
     git clone https://github.com/IntelPython/hpat.git
     conda build --python <3.6 or 3.7> -c numba -c conda-forge -c defaults -c intel hpat/buildscripts/hpat-conda-recipe/
+
+Build with setuptools:
+~~~~~~~~~~~~~~~~~~~~~~
+::
+
+    conda create -n HPAT -c ehsantn -c numba/label/dev -c anaconda -c conda-forge -c intel python=<3.6 or 3.7> pandas pyarrow h5py numba scipy boost libboost tbb-devel mkl-devel impi-devel impi_rt
+    activate HPAT
+    conda install vc vs2015_runtime vs2015_win-64
+    git clone https://github.com/IntelPython/hpat.git
+    cd hpat
+    set INCLUDE=%INCLUDE%;%CONDA_PREFIX%\Library\include
+    set LIB=%LIB%;%CONDA_PREFIX%\Library\lib
+    %CONDA_PREFIX%\Library\bin\mpivars.bat quiet
+    set HDF5_DIR=%CONDA_PREFIX%\Library
+    python setup.py develop
 
 .. "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if use_impi:
 
 if is_win:
     # use Intel MPI on Windows
-    MPI_LIBS = ['impi', 'impicxx']
+    MPI_LIBS = ['impi']
     # hdf5-parallel Windows build uses CMake which needs this flag
     H5_CPP_FLAGS = [('H5_BUILT_AS_DYNAMIC_LIB', None)]
 


### PR DESCRIPTION
Use impi-devel and impi_rt conda packages for
Windows instead of Intel(R) MPI.
This will remove requirement to have already
installed MPI for HPAT build on Windows.