### PR TITLE
[ENH] using path from root folder for 'gen_test_data' file

### DIFF
--- a/hpat/tests/test_dataframe.py
+++ b/hpat/tests/test_dataframe.py
@@ -9,7 +9,7 @@ import hpat
 from hpat.tests.test_utils import (count_array_REPs, count_parfor_REPs,
     count_parfor_OneDs, count_array_OneDs, dist_IR_contains, get_start_end)
 
-from .gen_test_data import ParquetGenerator
+from hpat.tests.gen_test_data import ParquetGenerator
 
 
 @hpat.jit

--- a/hpat/tests/test_series.py
+++ b/hpat/tests/test_series.py
@@ -10,7 +10,7 @@ from hpat.str_arr_ext import StringArray
 from hpat.tests.test_utils import (count_array_REPs, count_parfor_REPs,
     count_parfor_OneDs, count_array_OneDs, dist_IR_contains, get_start_end)
 
-from .gen_test_data import ParquetGenerator
+from hpat.tests.gen_test_data import ParquetGenerator
 
 _cov_corr_series = [(pd.Series(x), pd.Series(y)) for x, y in [
     (

--- a/hpat/tests/test_strings.py
+++ b/hpat/tests/test_strings.py
@@ -10,7 +10,7 @@ import re
 import pyarrow.parquet as pq
 from hpat.str_arr_ext import StringArray
 from hpat.str_ext import unicode_to_std_str, std_str_to_unicode
-from .gen_test_data import ParquetGenerator
+from hpat.tests.gen_test_data import ParquetGenerator
 
 
 class TestString(unittest.TestCase):


### PR DESCRIPTION
Now you should be able test as follows:
`python hpat/tests/test_series.py`

Using the previous import it was possible to test only in this way:
`python -m unittest hpat.tests.test_series`