### PR TITLE
Add tests

### DIFF
--- a/tests_perf/tests/algorithms.py
+++ b/tests_perf/tests/algorithms.py
@@ -134,3 +134,112 @@ class MinMax:
             return self._max(self.series)
         if implementation == Impl.interpreted_python.value:
             return self.series.max()
+
+
+class Nlargest:
+    params = [
+        [5 * 10 ** 7 + 513],
+        [Impl.interpreted_python.value, Impl.compiled_python.value]
+    ]
+    param_names = ['size', 'implementation']
+
+    def setup(self, size, implementation):
+        self.series = FloatSeriesGenerator(size).generate()
+
+    @staticmethod
+    @hpat.jit
+    def _nlargest(series):
+        return series.nlargest()
+
+    def time_nlargest(self, size, implementation):
+        if implementation == Impl.compiled_python.value:
+            return self._nlargest(self.series)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.nlargest()
+
+class Nsmallest:
+    params = [
+        [8 * 10 ** 7 + 513],
+        [Impl.interpreted_python.value, Impl.compiled_python.value]
+    ]
+    param_names = ['size', 'implementation']
+
+    def setup(self, size, implementation):
+        self.series = FloatSeriesGenerator(size).generate()
+
+    @staticmethod
+    @hpat.jit
+    def _nsmallest(series):
+        return series.nsmallest()
+
+    def time_nsmallest(self, size, implementation):
+        if implementation == Impl.compiled_python.value:
+            return self._nsmallest(self.series)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.nsmallest()
+
+
+class Var:
+    params = [
+        [2 * 10 ** 8 + 513],
+        [Impl.interpreted_python.value, Impl.compiled_python.value]
+    ]
+    param_names = ['size', 'implementation']
+
+    def setup(self, size, implementation):
+        self.series = FloatSeriesGenerator(size).generate()
+
+    @staticmethod
+    @hpat.jit
+    def _var(series):
+        return series.var()
+
+    def time_var(self, size, implementation):
+        if implementation == Impl.compiled_python.value:
+            return self._var(self.series)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.var()
+
+
+class Mean:
+    params = [
+        [3 * 10 ** 8 + 513],
+        [Impl.interpreted_python.value, Impl.compiled_python.value]
+    ]
+    param_names = ['size', 'implementation']
+
+    def setup(self, size, implementation):
+        self.series = FloatSeriesGenerator(size).generate()
+
+    @staticmethod
+    @hpat.jit
+    def _mean(series):
+        return series.mean()
+
+    def time_mean(self, size, implementation):
+        if implementation == Impl.compiled_python.value:
+            return self._mean(self.series)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.mean()
+
+
+class Median:
+    params = [
+        [6 * 10 ** 7 + 513],
+        [Impl.interpreted_python.value, Impl.compiled_python.value]
+    ]
+    param_names = ['size', 'implementation']
+
+    def setup(self, size, implementation):
+        self.series = FloatSeriesGenerator(size).generate()
+
+    @staticmethod
+    @hpat.jit
+    def _median(series):
+        return series.median()
+
+    def time_median(self, size, implementation):
+        if implementation == Impl.compiled_python.value:
+            return self._median(self.series)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.median()

--- a/tests_perf/tests/algorithms.py
+++ b/tests_perf/tests/algorithms.py
@@ -136,6 +136,65 @@ class MinMax:
             return self.series.max()
 
 
+class Correlation:
+    params = [
+        [10 ** 8 + 513],
+        [Impl.interpreted_python.value, Impl.compiled_python.value]
+    ]
+    param_names = ['size', 'implementation']
+
+    def setup(self, size, implementation):
+        self.series = FloatSeriesGenerator(size).generate()
+        self.series2 = FloatSeriesGenerator(size).generate()
+
+    @staticmethod
+    @hpat.jit
+    def _cov(series, series2):
+        return series.cov(series2)
+
+    def time_cov(self, size, implementation):
+        """Time both interpreted and compiled Series.cov"""
+        if implementation == Impl.compiled_python.value:
+            return self._cov(self.series, self.series2)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.cov(self.series2)
+
+    @staticmethod
+    @hpat.jit
+    def _corr(series, series2):
+        return series.corr(series2)
+
+    def time_corr(self, size, implementation):
+        """Time both interpreted and compiled Series.cov"""
+        if implementation == Impl.compiled_python.value:
+            return self._corr(self.series, self.series2)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.corr(self.series2)
+
+
+class Sum:
+    params = [
+        [10 ** 8 + 513],
+        [Impl.interpreted_python.value, Impl.compiled_python.value]
+    ]
+    param_names = ['size', 'implementation']
+
+    def setup(self, size, implementation):
+        self.series = FloatSeriesGenerator(size=size).generate()
+
+    @staticmethod
+    @hpat.jit
+    def _sum(series):
+        return series.sum()
+
+    def time_sum(self, size, implementation):
+        """Time both interpreted and compiled Series.sum"""
+        if implementation == Impl.compiled_python.value:
+            return self._sum(self.series)
+        if implementation == Impl.interpreted_python.value:
+            return self.series.sum()
+
+
 class Nlargest:
     params = [
         [5 * 10 ** 7 + 513],


### PR DESCRIPTION

Row # | Benchmark | Result, s | Min, s | Arithmetic Mean, s | Max, s | Standard Deviation, s
-- | -- | -- | -- | -- | -- | --
1 | algorithms.Nlargest.time_nlargest(50000513, interpreted_python) | 1.23969 | 1.19073 | 1.28418 | 1.48635 | 0.09741
2 | algorithms.Nlargest.time_nlargest(50000513, compiled_python) | 0.07153 | 0.07060 | 0.07347 | 0.09008 | 0.00595
3 | algorithms.Nsmallest.time_nsmallest(80000513, interpreted_python) | 1.29811 | 1.28206 | 1.31318 | 1.37734 | 0.03372
4 | algorithms.Nsmallest.time_nsmallest(80000513, compiled_python) | 0.11481 | 0.11163 | 0.13987 | 0.21200 | 0.04237
5 | algorithms.Var.time_var(200000513, interpreted_python) | 1.56226 | 1.40829 | 1.52438 | 1.62742 | 0.08441
6 | algorithms.Var.time_var(200000513, compiled_python) | 0.74962 | 0.71392 | 0.77756 | 0.87654 | 0.06455
7 | algorithms.Mean.time_mean(300000513, interpreted_python) | 1.46523 | 1.36765 | 1.46518 | 1.59163 | 0.06925
8 | algorithms.Mean.time_mean(300000513, compiled_python) | 0.66372 | 0.63233 | 0.68529 | 0.74664 | 0.04450
9 | algorithms.Median.time_median(60000513, interpreted_python) | 1.39547 | 1.33259 | 1.39600 | 1.47150 | 0.05800
10 | algorithms.Median.time_median(60000513, compiled_python) | 1.17271 | 1.11581 | 1.16605 | 1.20239 | 0.02990

