### PR TITLE
Implement Series.copy() in new style

### DIFF
--- a/hpat/datatypes/hpat_pandas_series_functions.py
+++ b/hpat/datatypes/hpat_pandas_series_functions.py
@@ -428,6 +428,53 @@ def hpat_pandas_series_append(self, to_append):
     return hpat_pandas_series_append_impl
 
 
+@overload_method(SeriesType, 'copy')
+def hpat_pandas_series_copy(self, deep=True):
+    """
+    Pandas Series method :meth:`pandas.Series.copy` implementation.
+
+    .. only:: developer
+
+       Test: python -m hpat.runtests hpat.tests.test_series.TestSeries.test_series_copy_str1
+       Test: python -m hpat.runtests hpat.tests.test_series.TestSeries.test_series_copy_int1
+       Test: python -m hpat.runtests hpat.tests.test_series.TestSeries.test_series_copy_deep
+
+    Parameters
+    -----------
+    self: :class:`pandas.Series`
+        input arg
+    deep: :obj:`bool`, default :obj:`True`
+        Make a deep copy, including a copy of the data and the indices.
+        With deep=False neither the indices nor the data are copied.
+        [HPAT limitations]:
+            - deep=False: shallow copy of index is not supported
+
+    Returns
+    -------
+    :obj:`pandas.Series` or :obj:`pandas.DataFrame`
+        Object type matches caller.
+    """
+    _func_name = 'Method Series.copy().'
+
+    if (isinstance(self, SeriesType) and
+        (isinstance(deep, (types.Omitted, types.Boolean)) or deep == True)
+    ):
+        if isinstance(self.index, types.NoneType):
+            def hpat_pandas_series_copy_impl(self, deep=True):
+                if deep:
+                    return pandas.Series(self._data.copy())
+                else:
+                    return pandas.Series(self._data)
+            return hpat_pandas_series_copy_impl
+        else:
+            def hpat_pandas_series_copy_impl(self, deep=True):
+                if deep:
+                    return pandas.Series(self._data.copy(), index=self._index.copy())
+                else:
+                    return pandas.Series(self._data, index=self._index.copy())
+            return hpat_pandas_series_copy_impl
+
+
 @overload_method(SeriesType, 'groupby')
 def hpat_pandas_series_groupby(
         self,

--- a/hpat/hiframes/hiframes_typed.py
+++ b/hpat/hiframes/hiframes_typed.py
@@ -1043,7 +1043,7 @@ class HiFramesTyped(object):
             return self._replace_func(_binop_impl, [series_var] + rhs.args)
 
         # functions we revert to Numpy for now, otherwise warning
-        _conv_to_np_funcs = ('copy', 'cumsum', 'cumprod', 'astype')
+        _conv_to_np_funcs = ('cumsum', 'cumprod', 'astype')
         # TODO: handle series-specific cases for this funcs
         if (not func_name.startswith("values.") and func_name
                 not in _conv_to_np_funcs):

--- a/hpat/hiframes/pd_series_ext.py
+++ b/hpat/hiframes/pd_series_ext.py
@@ -460,18 +460,18 @@ class SeriesAttribute(AttributeTemplate):
             sig.return_type = if_arr_to_series_type(sig.return_type)
         return sig
 
-    @bound_function("array.copy")
-    def resolve_copy(self, ary, args, kws):
-        # TODO: copy other types like list(str)
-        dtype = ary.dtype
-        if dtype == string_type:
-            ret_type = SeriesType(string_type)
-            sig = signature(ret_type, *args)
-        else:
-            resolver = ArrayAttribute.resolve_copy.__wrapped__
-            sig = resolver(self, ary.data, args, kws)
-            sig.return_type = if_arr_to_series_type(sig.return_type)
-        return sig
+    # @bound_function("array.copy")
+    # def resolve_copy(self, ary, args, kws):
+    #     # TODO: copy other types like list(str)
+    #     dtype = ary.dtype
+    #     if dtype == string_type:
+    #         ret_type = SeriesType(string_type)
+    #         sig = signature(ret_type, *args)
+    #     else:
+    #         resolver = ArrayAttribute.resolve_copy.__wrapped__
+    #         sig = resolver(self, ary.data, args, kws)
+    #         sig.return_type = if_arr_to_series_type(sig.return_type)
+    #     return sig
 
     @bound_function("series.rolling")
     def resolve_rolling(self, ary, args, kws):
@@ -992,6 +992,7 @@ for fname in ["cumsum", "cumprod"]:
 
 # TODO: add itemsize, strides, etc. when removed from Pandas
 _not_series_array_attrs = ['flat', 'ctypes', 'itemset', 'reshape', 'sort', 'flatten',
+                           'resolve_copy',
                            'resolve_sum',
                            'resolve_take', 'resolve_max', 'resolve_min', 'resolve_nunique']
 


### PR DESCRIPTION
Note: shallow copy for index is not supported yet.