### PR TITLE
Use Jinja2 templates in hpat-conda-recipe

### DIFF
--- a/buildscripts/hpat-conda-recipe/meta.yaml
+++ b/buildscripts/hpat-conda-recipe/meta.yaml
@@ -1,3 +1,6 @@
+{% set PYARROW_VERSION = ">=0.14.0,<0.15.0a0" %}
+{% set ARROW_CPP_VERSION = ">=0.14.0,<0.15.0a0" %}
+
 package:
   name: hpat
   version: {{ GIT_DESCRIBE_TAG }}
@@ -26,8 +29,8 @@ requirements:
     - numba ==0.45
     - numpy
     - pandas >=0.23
-    - pyarrow ==0.14.1
-    - arrow-cpp ==0.14.1
+    - pyarrow {{ PYARROW_VERSION }}
+    - arrow-cpp {{ ARROW_CPP_VERSION }}
     - boost
     - hdf5
     - h5py
@@ -41,8 +44,8 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - pandas >=0.23
-    - pyarrow ==0.14.1
-    - arrow-cpp ==0.14.1
+    - pyarrow {{ PYARROW_VERSION }}
+    - arrow-cpp {{ ARROW_CPP_VERSION }}
     - boost
     - numba ==0.45
     - mpich # [not win]

--- a/buildscripts/hpat-conda-recipe/meta.yaml
+++ b/buildscripts/hpat-conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set PYARROW_VERSION = ">=0.14.0,<0.15.0a0" %}
-{% set ARROW_CPP_VERSION = ">=0.14.0,<0.15.0a0" %}
+{% set PYARROW_VERSION = "==0.15.0" %}
+{% set ARROW_CPP_VERSION = "==0.15.0" %}
 
 package:
   name: hpat


### PR DESCRIPTION
This PR eliminates duplication of package versions using Jinja2 templates.
It is answer to https://github.com/IntelPython/hpat/pull/249#discussion_r338120346.